### PR TITLE
Add Remote BrowserWindow Support

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -40,7 +40,9 @@ class ProgressBar {
 				maximizable: false,
 				width: 500,
 				height: 170
-			}
+			},
+
+      		remoteWindow: null
 		};
 		
 		this._styleSelector = {
@@ -243,8 +245,12 @@ class ProgressBar {
 	}
 	
 	_createWindow() {
-		this._window = new BrowserWindow(this._options.browserWindow);
-		
+	  	if (this._options.remoteWindow) {
+			this._window = new this._options.remoteWindow(this._options.browserWindow);
+		} else {
+			this._window = new BrowserWindow(this._options.browserWindow);
+		}
+
 		this._window.setMenu(null);
 		
 		if(this._options.debug){


### PR DESCRIPTION
Remote BrowserWindow Support. This issue was mentioned in #11. I took a look and fixed it.
I added the option `remoteWindow, which can be set.
In the `_createWindow` method, I checked if the remoteWindow is setted and create the window out of it.

How to use it:
```
  const progressbar = new ProgressBar({
    indeterminate: false,
    text: 'Preparing data...',
    detail: 'Wait',
    remoteWindow: remote.BrowserWindow
  });
```

Best regards
Stefan