### PR TITLE
Enable nodeIntegration by default - Fix issue #10

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -39,7 +39,10 @@ class ProgressBar {
 				minimizable: false,
 				maximizable: false,
 				width: 500,
-				height: 170
+				height: 170,
+				webPreferences: {
+					nodeIntegration: true
+				},
 			}
 		};
 		


### PR DESCRIPTION
Enable nodeIntegration by default

Fix for https://github.com/AndersonMamede/electron-progressbar/issues/10
