### PR TITLE
Fix rendering title, text repeatedly, Add functions to use language for html because of SEO and Font rendering.

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -528,13 +528,14 @@ const htmlContent = `
 					elements.progressBarContainer.appendChild(elements.progressBar);
 				}
 				
+				elements.text.innerHTML = currentValue.text;
+				elements.detail.innerHTML = currentValue.detail;
+				
 				window.requestAnimationFrame(synchronizeUi);
 			}
 			
 			function synchronizeUi(){
 				elements.progressBar.value = currentValue.progress;
-				elements.text.innerHTML = currentValue.text;
-				elements.detail.innerHTML = currentValue.detail;
 				window.requestAnimationFrame(synchronizeUi);
 			}
 			

--- a/source/index.js
+++ b/source/index.js
@@ -18,6 +18,7 @@ class ProgressBar {
 			title: 'Wait...',
 			text: 'Wait...',
 			detail: null,
+			lang: 'en-us',
 			
 			style: {
 				text: {},
@@ -272,7 +273,7 @@ class ProgressBar {
 			this._updateTaskbarProgress();
 		});
 		
-		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent(htmlContent));
+		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent(htmlContent.replace('{{REPLACE:LANG}}', this._options.lang)));
 		
 		this._window.webContents.on('did-finish-load', () => {
 			if (this._options.text !== null) {
@@ -352,7 +353,7 @@ class ProgressBar {
 
 const htmlContent = `
 <!DOCTYPE html>
-<html>
+<html lang={{REPLACE:LANG}}>
 	<head>
 		<meta charset="UTF-8">
 		<style>


### PR DESCRIPTION
I was having an issue where the title and text options were repeatedly being called within the requestAnimationFrame loop and I couldn't figure out why. Therefore, I wanted to fix that issue.

Also, I thought it would be helpful to add a feature that allows the language attribute to be added to the HTML for SEO and font rendering purposes.

Please review these changes and let me know if you have any other suggestions. Thank you.