### PR TITLE
✨ Create the customHTML option to customize htmlContent

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -276,7 +276,7 @@ class ProgressBar {
 		});
 		
 		const langAttribute = this._options.lang ? `lang="${this._options.lang}"` : "";
-		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent((customHTML || htmlContent).replace('{{REPLACE:LANG}}', langAttribute)));
+		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent((this.options.customHTML || htmlContent).replace('{{REPLACE:LANG}}', langAttribute)));
 		
 		this._window.webContents.on('did-finish-load', () => {
 			if (this._options.text !== null) {

--- a/source/index.js
+++ b/source/index.js
@@ -19,6 +19,7 @@ class ProgressBar {
 			text: 'Wait...',
 			detail: null,
 			lang: '',
+			customHTML: null,
 			
 			style: {
 				text: {},
@@ -275,7 +276,7 @@ class ProgressBar {
 		});
 		
 		const langAttribute = this._options.lang ? `lang="${this._options.lang}"` : "";
-		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent(htmlContent.replace('{{REPLACE:LANG}}', langAttribute)));
+		this._window.loadURL('data:text/html;charset=UTF8,' + encodeURIComponent((customHTML || htmlContent).replace('{{REPLACE:LANG}}', langAttribute)));
 		
 		this._window.webContents.on('did-finish-load', () => {
 			if (this._options.text !== null) {


### PR DESCRIPTION
I tried to customize the file using the title and text inside the htmlContent as much as possible, but it was not easy.

So, I would like to add an option to replace all htmlContent.

Then, it looks good because it seems that you can dynamically copy and take some contents from htmlContent through the customHTML option rather than htmlContent, and then customize the title and text options.